### PR TITLE
fix Makefile file name / change test file's openssl path / fix TLS_REMOTE_HOSTNAME's level

### DIFF
--- a/test_files/Makefile
+++ b/test_files/Makefile
@@ -3,11 +3,11 @@ CC_FLAGS = -w -g -Wall -O3
  
 EXEC = all
 PASS_TEST = passfd_client
-PASS_TEST_SRC = passfd_client.c
+PASS_TEST_SRC = passfd_client.t.c
 PASS_TEST_OBJ = $(PASS_TEST_SRC:.c=.o)
 
 TESTS = tests
-TESTS_SRC = tests.c
+TESTS_SRC = tests.t.c
 TESTS_OBJ = $(TESTS_SRC:.c=.o)
 
 SOURCES_ALL = $(wildcard *.c)

--- a/test_files/tests.t.c
+++ b/test_files/tests.t.c
@@ -86,8 +86,8 @@ void run_s_server(){
 		printf("starting s_server\n");
 		pid = fork();
 		if (pid == 0) {
-			char *args[] = {"/bin/openssl", "s_server", "-cert", "tls_server/pem_files/certificate.pem", "-key", "tls_server/pem_files/key.pem", "-accept", "8888", "-quiet", NULL};
-			execv("/bin/openssl", args);
+			char *args[] = {"/usr/bin/openssl", "s_server", "-cert", "tls_server/pem_files/certificate.pem", "-key", "tls_server/pem_files/key.pem", "-accept", "8888", "-quiet", NULL};
+			execv("/usr/bin/openssl", args);
 			fprintf(stderr, "Failed to execute s_server\n");
 		} else {
 			sleep(1);
@@ -456,7 +456,7 @@ void run_connect_benchmark(void) {
 	}
 
 	const char hostname[] = "www.google.com";
-        if (setsockopt(sock_fd, IPPROTO_IP, TLS_REMOTE_HOSTNAME, hostname, sizeof(hostname)) == -1) {
+        if (setsockopt(sock_fd, IPPROTO_TLS, TLS_REMOTE_HOSTNAME, hostname, sizeof(hostname)) == -1) {
 		perror("setsockopt: TLS_REMOTE_HOSTNAME");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
This PR corrects three parts:

 - `Makefile` in `test_files` does not match the c source file names.

 - Seems in many computers, `openssl` resides at `/usr/bin` rather than `/bin`, which differs from `nc`.

 - `TLS_REMOTE_HOSTNAME` must associate with `IPPROTO_TLS` rather than `IPPROTO_IP`. Otherwise, the SSA will let `inet_stream_ops.setsockopt` process the set request of `TLS_REMOTE_HOSTNAME` and causes "protocol not supported".